### PR TITLE
Add series import feature

### DIFF
--- a/lib/src/models/m3u_series.dart
+++ b/lib/src/models/m3u_series.dart
@@ -1,0 +1,23 @@
+class M3uEpisode {
+  final String name;
+  final String url;
+  final int season;
+  final int episode;
+  final String logo;
+
+  M3uEpisode({
+    required this.name,
+    required this.url,
+    required this.season,
+    required this.episode,
+    required this.logo,
+  });
+}
+
+class M3uSeries {
+  final String name;
+  final String logo;
+  final List<M3uEpisode> episodes;
+
+  M3uSeries({required this.name, required this.logo, required this.episodes});
+}

--- a/lib/src/screens/series_list_screen.dart
+++ b/lib/src/screens/series_list_screen.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+import '../models/m3u_series.dart';
+import '../services/m3u_service.dart';
+
+class SeriesListScreen extends StatefulWidget {
+  const SeriesListScreen({super.key, required this.path});
+
+  final String path;
+
+  @override
+  State<SeriesListScreen> createState() => _SeriesListScreenState();
+}
+
+class _SeriesListScreenState extends State<SeriesListScreen> {
+  final M3uService _service = const M3uService();
+  final TextEditingController _queryCtrl = TextEditingController();
+  List<M3uSeries> _series = [];
+  bool _loading = true;
+  String _query = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    final list = await _service.loadSeries(
+      widget.path,
+      query: _query,
+    );
+    if (!mounted) return;
+    setState(() {
+      _series = list;
+      _loading = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _queryCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Séries')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: TextField(
+              controller: _queryCtrl,
+              decoration: const InputDecoration(labelText: 'Rechercher'),
+              onChanged: (v) {
+                setState(() => _query = v);
+                if (v.isEmpty || v.length >= 3) {
+                  _load();
+                }
+              },
+            ),
+          ),
+          if (_loading) const LinearProgressIndicator(),
+          Expanded(
+            child: ListView.builder(
+              itemCount: _series.length,
+              itemBuilder: (context, index) {
+                final serie = _series[index];
+                return ListTile(
+                  minVerticalPadding: 8,
+                  leading: serie.logo.isNotEmpty
+                      ? Image.network(
+                          serie.logo,
+                          width: 64,
+                          height: 64,
+                          errorBuilder: (_, __, ___) =>
+                              const Icon(Icons.image_not_supported),
+                        )
+                      : const Icon(Icons.image_not_supported),
+                  title: Text(serie.name),
+                  subtitle: Text('${serie.episodes.length} épisodes'),
+                  onTap: () => Navigator.pop(context, serie),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/services/m3u_service.dart
+++ b/lib/src/services/m3u_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import '../models/iptv_models.dart';
+import '../models/m3u_series.dart';
 
 class M3uService {
   const M3uService();
@@ -88,5 +89,63 @@ class M3uService {
       }
     }
     return result;
+  }
+
+  Future<List<M3uSeries>> loadSeries(
+    String path, {
+    String query = '',
+  }) async {
+    final file = File(path);
+    if (!await file.exists()) return [];
+    final lines =
+        file.openRead().transform(utf8.decoder).transform(const LineSplitter());
+    String? name;
+    String? logo;
+    final Map<String, M3uSeries> map = {};
+    final lowerQuery = query.toLowerCase();
+    final reg =
+        RegExp(r'(.+?)S(\d{1,2})[^\d]?E(\d{1,2})', caseSensitive: false);
+    await for (final line in lines) {
+      if (line.startsWith('#EXTINF')) {
+        final comma = line.indexOf(',');
+        if (comma >= 0 && comma + 1 < line.length) {
+          name = line.substring(comma + 1).trim();
+        } else {
+          name = null;
+        }
+        final match =
+            RegExp('tvg-logo="([^"]*)"', caseSensitive: false).firstMatch(line);
+        logo = match != null ? match.group(1) : '';
+      } else if (line.trim().isNotEmpty && !line.startsWith('#')) {
+        if (name != null) {
+          final url = line.trim();
+          final m = reg.firstMatch(name!);
+          if (m != null) {
+            final serieName = m.group(1)!.trim();
+            final season = int.tryParse(m.group(2) ?? '1') ?? 1;
+            final episode = int.tryParse(m.group(3) ?? '1') ?? 1;
+            if (lowerQuery.isEmpty ||
+                serieName.toLowerCase().contains(lowerQuery)) {
+              final ep = M3uEpisode(
+                name: name!,
+                url: url,
+                season: season,
+                episode: episode,
+                logo: logo ?? '',
+              );
+              map.putIfAbsent(
+                serieName,
+                () =>
+                    M3uSeries(name: serieName, logo: logo ?? '', episodes: []),
+              );
+              map[serieName]!.episodes.add(ep);
+            }
+          }
+          name = null;
+          logo = null;
+        }
+      }
+    }
+    return map.values.toList();
   }
 }

--- a/test/m3u_service_series_test.dart
+++ b/test/m3u_service_series_test.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_iptv_player/src/services/m3u_service.dart';
+
+void main() {
+  test('loadSeries groups episodes by series', () async {
+    final file = File('${Directory.systemTemp.path}/series_test.m3u');
+    await file.writeAsString(
+      '#EXTM3U\n'
+      '#EXTINF:-1 tvg-logo="1.png",Show One S01 E01\n'
+      'http://example.com/1\n'
+      '#EXTINF:-1 tvg-logo="1.png",Show One S01 E02\n'
+      'http://example.com/2\n'
+      '#EXTINF:-1 tvg-logo="2.png",Show Two S02 E01\n'
+      'http://example.com/3\n',
+    );
+    final service = const M3uService();
+    final result = await service.loadSeries(file.path);
+    expect(result.length, 2);
+    final one = result.firstWhere((e) => e.name == 'Show One');
+    expect(one.episodes.length, 2);
+    await file.delete();
+  });
+}


### PR DESCRIPTION
## Summary
- allow adding series folders from M3U playlists
- parse series and episodes in `M3uService`
- provide `SeriesListScreen` UI to select a series
- support returning multiple created items from `ItemFormScreen`
- test parsing of series from M3U files

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test --coverage`
- `flutter test test/m3u_service_series_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_6873b385e8dc8328bd6594e8adcf7b08