### PR TITLE
Fix viewed interactions and display

### DIFF
--- a/lib/src/screens/home_screen.dart
+++ b/lib/src/screens/home_screen.dart
@@ -26,6 +26,15 @@ class _HomeScreenState extends State<HomeScreen> {
   final Logger _logger = Logger();
   List<IptvItem> _allItems = [];
 
+  bool _isViewableMedia(IptvItem item) {
+    if (item.type != IptvItemType.media) return false;
+    if (item.links.isEmpty) return false;
+    return item.links.every((l) {
+      final url = l.url.toLowerCase();
+      return url.endsWith('.mp4') || url.endsWith('.mkv');
+    });
+  }
+
   @override
   void initState() {
     super.initState();
@@ -117,7 +126,7 @@ class _HomeScreenState extends State<HomeScreen> {
     try {
       await Process.start(exePath, [link.url], runInShell: true);
       final index = _allItems.indexWhere((e) => e.id == item.id);
-      if (index >= 0 && !_allItems[index].viewed) {
+      if (_isViewableMedia(item) && index >= 0 && !_allItems[index].viewed) {
         setState(() {
           _allItems[index] = IptvItem(
             id: item.id,

--- a/lib/src/screens/item_form_screen.dart
+++ b/lib/src/screens/item_form_screen.dart
@@ -33,6 +33,17 @@ class _ItemFormScreenState extends State<ItemFormScreen> {
   M3uSeries? _series;
   bool _viewed = false;
 
+  bool _onlyFileLinks(List<ChannelLink> links) {
+    if (links.isEmpty) return false;
+    return links.every((l) {
+      final url = l.url.toLowerCase();
+      return url.endsWith('.mp4') || url.endsWith('.mkv');
+    });
+  }
+
+  bool get _canBeViewed =>
+      _type == IptvItemType.media && _onlyFileLinks(_links);
+
   bool _isDownloadable(ChannelLink link) {
     final url = link.url.toLowerCase();
     return url.endsWith('.mp4') || url.endsWith('.mkv');
@@ -66,7 +77,7 @@ class _ItemFormScreenState extends State<ItemFormScreen> {
       logoUrl: _logoUrl,
       links: _links,
       parentId: widget.parentId ?? widget.item?.parentId,
-      viewed: _viewed,
+      viewed: _canBeViewed ? _viewed : false,
     );
   }
 
@@ -222,6 +233,7 @@ class _ItemFormScreenState extends State<ItemFormScreen> {
         } else {
           _links[index] = result;
         }
+        if (!_canBeViewed) _viewed = false;
       });
     }
   }
@@ -253,6 +265,7 @@ class _ItemFormScreenState extends State<ItemFormScreen> {
           );
           if (firstLogo.logo.isNotEmpty) _logoUrl = firstLogo.logo;
         }
+        if (!_canBeViewed) _viewed = false;
       });
     }
   }
@@ -376,12 +389,6 @@ class _ItemFormScreenState extends State<ItemFormScreen> {
                           ),
                         ],
                       ),
-                      CheckboxListTile(
-                        contentPadding: EdgeInsets.zero,
-                        title: const Text('Vu'),
-                        value: _viewed,
-                        onChanged: (v) => setState(() => _viewed = v ?? false),
-                      ),
                       ReorderableListView.builder(
                         shrinkWrap: true,
                         physics: const NeverScrollableScrollPhysics(),
@@ -392,6 +399,7 @@ class _ItemFormScreenState extends State<ItemFormScreen> {
                             if (newIndex > oldIndex) newIndex -= 1;
                             final item = _links.removeAt(oldIndex);
                             _links.insert(newIndex, item);
+                            if (!_canBeViewed) _viewed = false;
                           });
                         },
                         itemBuilder: (context, index) {
@@ -433,6 +441,7 @@ class _ItemFormScreenState extends State<ItemFormScreen> {
                                     onPressed: () {
                                       setState(() {
                                         _links.removeAt(index);
+                                        if (!_canBeViewed) _viewed = false;
                                       });
                                     },
                                   ),
@@ -444,6 +453,16 @@ class _ItemFormScreenState extends State<ItemFormScreen> {
                       ),
                     ],
                   ),
+                ),
+              ),
+            if (_canBeViewed)
+              Card(
+                margin: const EdgeInsets.only(top: 16),
+                child: SwitchListTile.adaptive(
+                  title: const Text('Marquer comme vu'),
+                  value: _viewed,
+                  onChanged: (v) => setState(() => _viewed = v),
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 16),
                 ),
               ),
             const SizedBox(height: 16),

--- a/lib/src/widgets/item_card.dart
+++ b/lib/src/widgets/item_card.dart
@@ -29,6 +29,17 @@ class _ItemCardState extends State<ItemCard> with TickerProviderStateMixin {
   int _selectedIndex = 0;
   int? _hoveredIndex;
 
+  bool get _shouldShowViewed {
+    if (!widget.item.viewed || widget.item.type != IptvItemType.media) {
+      return false;
+    }
+    final files = widget.item.links.every((l) {
+      final url = l.url.toLowerCase();
+      return url.endsWith('.mp4') || url.endsWith('.mkv');
+    });
+    return files;
+  }
+
   void _open() {
     if (widget.item.type == IptvItemType.folder) {
       widget.onOpenFolder?.call();
@@ -43,7 +54,6 @@ class _ItemCardState extends State<ItemCard> with TickerProviderStateMixin {
       setState(() => _expanded = !_expanded);
     }
   }
-
 
   @override
   Widget build(BuildContext context) {
@@ -185,10 +195,12 @@ class _ItemCardState extends State<ItemCard> with TickerProviderStateMixin {
                   ),
                 ),
               ),
-            if (widget.item.viewed && widget.item.type == IptvItemType.media)
+            if (_shouldShowViewed)
               Positioned.fill(
-                child: Container(
-                  color: Colors.black.withOpacity(0.4),
+                child: IgnorePointer(
+                  child: Container(
+                    color: Colors.black.withOpacity(0.4),
+                  ),
                 ),
               ),
             previewWidget,
@@ -224,7 +236,8 @@ class _ItemCardState extends State<ItemCard> with TickerProviderStateMixin {
                   itemBuilder: (context, i) {
                     final link = widget.item.links[i];
                     return InkWell(
-                      onHover: (hover) => setState(() => _hoveredIndex = hover ? i : null),
+                      onHover: (hover) =>
+                          setState(() => _hoveredIndex = hover ? i : null),
                       onTap: () => setState(() {
                         _selectedIndex = i;
                         _expanded = false;
@@ -238,13 +251,16 @@ class _ItemCardState extends State<ItemCard> with TickerProviderStateMixin {
                                   ? Colors.grey.shade300
                                   : Colors.transparent,
                           borderRadius: BorderRadius.vertical(
-                            top: i == 0 ? const Radius.circular(12) : Radius.zero,
+                            top: i == 0
+                                ? const Radius.circular(12)
+                                : Radius.zero,
                             bottom: i == widget.item.links.length - 1
                                 ? const Radius.circular(12)
                                 : Radius.zero,
                           ),
                         ),
-                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 6),
                         child: Row(
                           children: [
                             Expanded(


### PR DESCRIPTION
## Summary
- prevent overlay from blocking edit button interactions
- show dark overlay only for playable media files
- update "Vu" field logic so it only applies to mp4/mkv
- move "Vu" switch outside of links section and style it

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6873f6aed3348328a5b56c753fe546f6