### PR TITLE
Improve item UI and series import

### DIFF
--- a/lib/src/screens/item_form_screen.dart
+++ b/lib/src/screens/item_form_screen.dart
@@ -98,14 +98,16 @@ class _ItemFormScreenState extends State<ItemFormScreen> {
         parentId: parentId,
       ));
       for (final ep in bySeason[season]!) {
+        final epLabel =
+            'S${ep.season.toString().padLeft(2, '0')} E${ep.episode.toString().padLeft(2, '0')}';
         items.add(IptvItem(
           id: const Uuid().v4(),
           type: IptvItemType.media,
-          name: ep.name,
+          name: epLabel,
           logoUrl: ep.logo,
           links: [
             ChannelLink(
-              name: ep.name,
+              name: epLabel,
               url: ep.url,
               logo: ep.logo,
               resolution: '',

--- a/lib/src/widgets/item_card.dart
+++ b/lib/src/widgets/item_card.dart
@@ -28,6 +28,19 @@ class _ItemCardState extends State<ItemCard> with TickerProviderStateMixin {
   bool _expanded = false;
   int _selectedIndex = 0;
   int? _hoveredIndex;
+  late final ScrollController _scrollCtrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollCtrl = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollCtrl.dispose();
+    super.dispose();
+  }
 
   bool get _shouldShowViewed {
     if (!widget.item.viewed || widget.item.type != IptvItemType.media) {
@@ -115,6 +128,15 @@ class _ItemCardState extends State<ItemCard> with TickerProviderStateMixin {
                           size: 48,
                         ),
             ),
+            previewWidget,
+            if (_shouldShowViewed)
+              Positioned.fill(
+                child: IgnorePointer(
+                  child: Container(
+                    color: Colors.black.withOpacity(0.4),
+                  ),
+                ),
+              ),
             if (widget.item.type == IptvItemType.folder)
               Positioned(
                 top: 4,
@@ -195,15 +217,6 @@ class _ItemCardState extends State<ItemCard> with TickerProviderStateMixin {
                   ),
                 ),
               ),
-            if (_shouldShowViewed)
-              Positioned.fill(
-                child: IgnorePointer(
-                  child: Container(
-                    color: Colors.black.withOpacity(0.4),
-                  ),
-                ),
-              ),
-            previewWidget,
           ],
         ),
       ),
@@ -229,8 +242,11 @@ class _ItemCardState extends State<ItemCard> with TickerProviderStateMixin {
               ),
               constraints: const BoxConstraints(maxHeight: 200),
               child: Scrollbar(
+                controller: _scrollCtrl,
                 thumbVisibility: true,
+                interactive: true,
                 child: ListView.builder(
+                  controller: _scrollCtrl,
                   shrinkWrap: true,
                   itemCount: widget.item.links.length,
                   itemBuilder: (context, i) {


### PR DESCRIPTION
## Summary
- keep edit icon visible over viewed overlay
- ensure scrollbars work in item dropdowns
- label imported episodes by season/episode number only

## Testing
- `flutter analyze`
- `flutter test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6874b2e80060832890511641df7043ee