### PR TITLE
Improve mobile tap and VLC launch

### DIFF
--- a/lib/src/screens/home_screen.dart
+++ b/lib/src/screens/home_screen.dart
@@ -126,8 +126,9 @@ class _HomeScreenState extends State<HomeScreen> {
     if (Platform.isAndroid) {
       final intent = AndroidIntent(
         action: 'action_view',
-        data: link.url,
+        data: Uri.encodeFull(link.url),
         package: 'org.videolan.vlc',
+        type: 'video/*',
       );
       try {
         await intent.launch();

--- a/lib/src/widgets/playlist_card.dart
+++ b/lib/src/widgets/playlist_card.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:async';
 
 import 'package:flutter/material.dart';
 
@@ -22,6 +23,13 @@ class PlaylistCard extends StatefulWidget {
 
 class _PlaylistCardState extends State<PlaylistCard> {
   bool _hovered = false;
+  Timer? _hoverTimer;
+
+  @override
+  void dispose() {
+    _hoverTimer?.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -90,15 +98,25 @@ class _PlaylistCardState extends State<PlaylistCard> {
 
     return MouseRegion(
       onEnter: (_) => setState(() => _hovered = true),
-      onExit: (_) => setState(() => _hovered = false),
+      onExit: (_) {
+        _hoverTimer?.cancel();
+        setState(() => _hovered = false);
+      },
       child: InkWell(
         onTap: Platform.isAndroid || Platform.isIOS
             ? () {
                 if (_hovered) {
+                  _hoverTimer?.cancel();
                   widget.onSelect();
                   setState(() => _hovered = false);
                 } else {
                   setState(() => _hovered = true);
+                  _hoverTimer?.cancel();
+                  _hoverTimer = Timer(const Duration(seconds: 3), () {
+                    if (mounted) {
+                      setState(() => _hovered = false);
+                    }
+                  });
                 }
               }
             : widget.onSelect,


### PR DESCRIPTION
## Summary
- set timer to hide overlay after a single tap on mobile
- cancel overlay timer when opening
- handle VLC launch on Android with encoded URI and MIME type

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6874d3a193b08328b28705a20807631d