### PR TITLE
Update Android build tooling

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.2.1" apply false   // ou plus récent
+    id "com.android.application" version "8.4.0" apply false   // ou plus récent
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 


### PR DESCRIPTION
## Summary
- bump Gradle wrapper to 8.4
- use Android Gradle plugin 8.4.0

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test --coverage`
- `flutter build apk` *(fails: No Android SDK found)*

------
https://chatgpt.com/codex/tasks/task_e_6874dba237b483288f5b15768506127d